### PR TITLE
`views.AutocompleteJsonView` fix for Django>=3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ class AlbumAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
-            path('custom_search/', self.admin_site.admin_view(CustomSearchView.as_view(model_admin=self)),
+            # for Django<3.2 add `model_admin=self` param to the `as_view` call below:
+            path('custom_search/', self.admin_site.admin_view(CustomSearchView.as_view()),
                  name='custom_search'),
         ]
         return custom_urls + urls

--- a/admin_auto_filters/views.py
+++ b/admin_auto_filters/views.py
@@ -13,7 +13,12 @@ class AutocompleteJsonView(Base):
         return str(obj)
 
     def get(self, request, *args, **kwargs):
-        self.term = request.GET.get('term', '')
+        if not hasattr(self, 'model_admin') and hasattr(self, 'process_request'):
+            # Django>=3.2 initializes `model_admin` prop inside a view
+            # by `process_request` method:
+            self.term, self.model_admin, self.source_field, _ = self.process_request(request)
+        else:
+            self.term = request.GET.get('term', '')
         self.paginator_class = self.model_admin.paginator
         self.object_list = self.get_queryset()
         context = self.get_context_data()


### PR DESCRIPTION
## Custom autocomplete view fails with `Django>=3.2`

This code
```python
    def get_urls(self) -> List:
        from admin_auto_filters.views import AutocompleteJsonView
        custom_urls = [
            path(
                'autocomplete/',
                self.admin_site.admin_view(
                    AutocompleteJsonView.as_view(model_admin=self),
                ),
                name='autocomplete',
            ),
        ]
        return custom_urls + super().get_urls()
```
Gives this error:
```
TypeError: AutocompleteJsonView() received an invalid keyword 'model_admin'. as_view only accepts arguments that are already attributes of the class.
```

The reason: `django.contrib.admin.views.AutocompleteJsonView` class creates the `model_admin` property only during a requst processing.

Here is the commit in the Django repo - https://github.com/django/django/commit/3071660acfbdf4b5c59457c8e9dc345d5e8894c5